### PR TITLE
Wrappers: save to pdf via matplotlib 

### DIFF
--- a/qcodes/plots/pyqtgraph.py
+++ b/qcodes/plots/pyqtgraph.py
@@ -4,6 +4,7 @@ Live plotting using pyqtgraph
 import numpy as np
 import pyqtgraph as pg
 import pyqtgraph.multiprocess as pgmp
+from qtpy import QtWidgets
 import warnings
 from collections import namedtuple
 
@@ -27,6 +28,10 @@ class QtPlot(BasePlot):
 
         figsize: (width, height) tuple in pixels to pass to GraphicsWindow
             default (1000, 600)
+        fig_x_pos: fraction of screen width to place the figure at
+            0 is all the way to the left and
+            1 is all the way to the right.
+            default None let qt decide.
         interval: period in seconds between update checks
             default 0.25
         theme: tuple of (foreground_color, background_color), where each is
@@ -39,7 +44,8 @@ class QtPlot(BasePlot):
     rpg = None
 
     def __init__(self, *args, figsize=(1000, 600), interval=0.25,
-                 window_title='', theme=((60, 60, 60), 'w'), show_window=True, remote=True, **kwargs):
+                 window_title='', theme=((60, 60, 60), 'w'), show_window=True, remote=True, fig_x_position=None,
+                 **kwargs):
         super().__init__(interval)
 
         if 'windowTitle' in kwargs.keys():
@@ -58,6 +64,10 @@ class QtPlot(BasePlot):
         self.win = self.rpg.GraphicsWindow(title=window_title)
         self.win.setBackground(theme[1])
         self.win.resize(*figsize)
+        if fig_x_position:
+            _, _, width, height = QtWidgets.QDesktopWidget().screenGeometry().getCoords()
+            y_pos = self.win.y()
+            self.win.move(width * fig_x_position, y_pos)
         self.subplots = [self.add_subplot()]
 
         if args or kwargs:

--- a/qcodes/plots/qcmatplotlib.py
+++ b/qcodes/plots/qcmatplotlib.py
@@ -6,6 +6,7 @@ from collections import Mapping
 
 import matplotlib.pyplot as plt
 from matplotlib.transforms import Bbox
+from matplotlib import cm
 import numpy as np
 from numpy.ma import masked_invalid, getmask
 
@@ -226,6 +227,8 @@ class MatPlot(BasePlot):
                 # if any entire array is masked, don't draw at all
                 # there's nothing to draw, and anyway it throws a warning
                 return False
+        if 'cmap' not in kwargs:
+            kwargs['cmap'] = cm.hot
         pc = ax.pcolormesh(*args, **kwargs)
 
         if getattr(ax, 'qcodes_colorbar', None):

--- a/qcodes/plots/qcmatplotlib.py
+++ b/qcodes/plots/qcmatplotlib.py
@@ -229,6 +229,12 @@ class MatPlot(BasePlot):
                 return False
         if 'cmap' not in kwargs:
             kwargs['cmap'] = cm.hot
+        if 'edgecolors' not in kwargs:
+            # Matplotlib pcolormesh per default are drawn as individual patches lined up next to each other
+            # due to rounding this produces visible gaps in some pdf viewers. To prevent this we draw each
+            # mesh with a visible edge (slightly overlapping) this assumes alpha=1 or it will produce artifacts
+            # at the overlaps
+            kwargs['edgecolors'] = 'face'
         pc = ax.pcolormesh(*args, **kwargs)
 
         if getattr(ax, 'qcodes_colorbar', None):

--- a/qcodes/utils/wrappers.py
+++ b/qcodes/utils/wrappers.py
@@ -3,19 +3,24 @@ from os.path import abspath
 from os.path import sep
 from os import makedirs
 import logging
+from qtpy import QtWidgets
+
 from qcodes.plots.pyqtgraph import QtPlot
 from qcodes.plots.qcmatplotlib import MatPlot
 from IPython import get_ipython
-from matplotlib import cm
+
 CURRENT_EXPERIMENT  = {}
 CURRENT_EXPERIMENT["logging_enabled"] = False
 
-def init(mainfolder:str, sample_name: str):
+def init(mainfolder:str, sample_name: str, plot_x_position=0.66):
     """
 
     Args:
         mainfolder:  base location for the data
         sample_name:  name of the sample
+        plot_x_position: fractional of screen position to put QT plots.
+                         0 is all the way to the left and
+                         1 is all the way to the right.
 
     """
     if sep in sample_name:
@@ -30,9 +35,10 @@ def init(mainfolder:str, sample_name: str):
     CURRENT_EXPERIMENT["sample_name"] = sample_name
     CURRENT_EXPERIMENT['init']  = True
 
+    CURRENT_EXPERIMENT['plot_x_position'] = plot_x_position
+
     path_to_experiment_folder = sep.join([mainfolder, sample_name, ""])
     CURRENT_EXPERIMENT["exp_folder"] = path_to_experiment_folder
-
 
     try:
         makedirs(path_to_experiment_folder)
@@ -64,7 +70,7 @@ def init(mainfolder:str, sample_name: str):
 def _plot_setup(data, inst_meas, useQT=True):
     title = "{} #{:03d}".format(CURRENT_EXPERIMENT["sample_name"], data.location_provider.counter)
     if useQT:
-        plot = QtPlot()
+        plot = QtPlot(fig_x_position=CURRENT_EXPERIMENT['plot_x_position'])
     else:
         plot = MatPlot()
     for j, i in enumerate(inst_meas):
@@ -245,7 +251,7 @@ def show_num(id, useQT=False):
     for value in data.arrays.keys():
         if "set" not in value:
             if useQT:
-                plot = QtPlot(getattr(data, value))
+                plot = QtPlot(getattr(data, value), fig_x_position=CURRENT_EXPERIMENT['plot_x_position'])
                 title = "{} #{}".format(CURRENT_EXPERIMENT["sample_name"], str_id)
                 plot.subplots[0].setTitle(title)
                 plot.subplots[0].showGrid(True, True)

--- a/qcodes/utils/wrappers.py
+++ b/qcodes/utils/wrappers.py
@@ -103,6 +103,33 @@ def _plot_setup(data, inst_meas, useQT=True):
                     plot.subplots[j].set_title("")
     return plot
 
+
+def _save_individual_plots(data, inst_meas):
+    title = "{} #{:03d}".format(CURRENT_EXPERIMENT["sample_name"], data.location_provider.counter)
+    counter_two = 0
+    for j, i in enumerate(inst_meas):
+        if getattr(i, "names", False):
+            # deal with multidimensional parameter
+            for k, name in enumerate(i.names):
+                counter_two += 1
+                plot = MatPlot()
+                inst_meas_name = "{}_{}".format(i._instrument.name, name)
+                plot.add(getattr(data, inst_meas_name))
+                plot.subplots[0].set_title(title)
+                plot.subplots[0].grid()
+                plot.save("{}_{:03d}.pdf".format(plot.get_default_title(), counter_two))
+        else:
+            counter_two += 1
+            plot = MatPlot()
+            # simple_parameters
+            inst_meas_name = "{}_{}".format(i._instrument.name, i.name)
+            plot.add(getattr(data, inst_meas_name))
+            plot.subplots[0].set_title(title)
+            plot.subplots[0].grid()
+            plot.save("{}_{:03d}.pdf".format(plot.get_default_title(), counter_two))
+
+
+
 def do1d(inst_set, start, stop, division, delay, *inst_meas):
     """
 
@@ -125,8 +152,7 @@ def do1d(inst_set, start, stop, division, delay, *inst_meas):
         _ = loop.with_bg_task(plot.update, plot.save).run()
     except KeyboardInterrupt:
         print("Measurement Interrupted")
-    staticplot = _plot_setup(data, inst_meas, useQT=False)
-    staticplot.save(staticplot.get_default_title()+'.pdf')
+    _save_individual_plots(data, inst_meas)
     return plot, data
 
 
@@ -157,8 +183,7 @@ def do1dDiagonal(inst_set, inst2_set, start, stop, division, delay, start2, slop
         _ = loop.with_bg_task(plot.update, plot.save).run()
     except KeyboardInterrupt:
         print("Measurement Interrupted")
-    staticplot = _plot_setup(data, inst_meas, useQT=False)
-    staticplot.save(staticplot.get_default_title()+'.pdf')
+    _save_individual_plots(data, inst_meas)
     return plot, data
 
 
@@ -194,8 +219,7 @@ def do2d(inst_set, start, stop, division, delay, inst_set2, start2, stop2, divis
         _ = loop.with_bg_task(plot.update, plot.save).run()
     except KeyboardInterrupt:
         print("Measurement Interrupted")
-    staticplot = _plot_setup(data, inst_meas, useQT=False)
-    staticplot.save(staticplot.get_default_title()+'.pdf')
+    _save_individual_plots(data, inst_meas)
     return plot, data
 
 

--- a/qcodes/utils/wrappers.py
+++ b/qcodes/utils/wrappers.py
@@ -199,7 +199,7 @@ def do2d(inst_set, start, stop, division, delay, inst_set2, start2, stop2, divis
     return plot, data
 
 
-def show_num(id):
+def show_num(id, useQT=False):
     """
     Show  and return plot and data for id in current instrument.
     Args:
@@ -220,9 +220,15 @@ def show_num(id):
     plots = []
     for value in data.arrays.keys():
         if "set" not in value:
-            plot = QtPlot(getattr(data, value))
-            title = "{} #{}".format(CURRENT_EXPERIMENT["sample_name"], str_id)
-            plot.subplots[0].setTitle(title)
-            plot.subplots[0].showGrid(True, True)
+            if useQT:
+                plot = QtPlot(getattr(data, value))
+                title = "{} #{}".format(CURRENT_EXPERIMENT["sample_name"], str_id)
+                plot.subplots[0].setTitle(title)
+                plot.subplots[0].showGrid(True, True)
+            else:
+                plot = MatPlot(getattr(data, value))
+                title = "{} #{}".format(CURRENT_EXPERIMENT["sample_name"], str_id)
+                plot.subplots[0].set_title(title)
+                plot.subplots[0].grid()
             plots.append(plot)
     return data, plots


### PR DESCRIPTION
Add automatic saving of pdf to wrappers.

In addition:

* Change default matplotlib colormap to match pyqtgraph
* Hack around aliasing issue in pcolormesh To see this in action look at 
[031.pdf](https://github.com/qdev-dk/Qcodes/files/841937/031.pdf)
renders correctly in Chrome but has visual gaps in OSX Preview and probably others
as seen in this screenshot:
![test](https://cloud.githubusercontent.com/assets/548266/23910062/ca13e39c-08d8-11e7-96e9-670cc4c18811.png)


@giulioungaretti 
