### PR TITLE
Support device annotation in spyder

### DIFF
--- a/qcodes/utils/qcodes_device_annotator.py
+++ b/qcodes/utils/qcodes_device_annotator.py
@@ -303,7 +303,7 @@ class MakeDeviceImage(qt.QWidget):
                     if paramsettings.get('labelstring'):
                         label_string = paramsettings.get('labelstring')
                     else:
-                        label_string = "{}_{} ".format(instrument, parameter)
+                        label_string = "{}_{} ".format(key, val)
                     if paramsettings.get('update'):
                         #parameters that are sweeped should be red.
                         painter.setBrush(gui.QColor(255, 0, 0, 100))

--- a/qcodes/utils/qcodes_device_annotator.py
+++ b/qcodes/utils/qcodes_device_annotator.py
@@ -11,7 +11,7 @@ import PyQt5.QtCore as core
 from shutil import copyfile
 import copy
 from qcodes.instrument.channel import ChannelList
-from qcodes.utils.helpers import forground_qt_window
+from qcodes.utils.helpers import foreground_qt_window
 
 class MakeDeviceImage(qt.QWidget):
     """
@@ -90,7 +90,7 @@ class MakeDeviceImage(qt.QWidget):
         self.setWindowTitle('Generate annotated device image')
         self.show()
         self.raise_()
-        forground_qt_window(self)
+        foreground_qt_window(self)
 
     def select_font(self):
 

--- a/qcodes/utils/qcodes_device_annotator.py
+++ b/qcodes/utils/qcodes_device_annotator.py
@@ -205,6 +205,9 @@ class MakeDeviceImage(qt.QWidget):
         # Now forget about the original
         self.filename = rawpath
 
+        datafilename = os.path.join(self.folder, 'deviceimage_annotations.json')
+        with open(datafilename, 'w') as fid:
+            json.dump(self._data, fid)
         self.close()
 
     @staticmethod
@@ -322,11 +325,8 @@ class DeviceImage:
         else:
             app = qt.QApplication.instance()
         imagedrawer = MakeDeviceImage(self.folder, self.station)
+        print("Please annotate device image")
         app.exec_()
-        imagedrawer.close()
-        self._data = imagedrawer._data
-        self.filename = imagedrawer.filename
-        self.saveAnnotations()
 
     def saveAnnotations(self):
         """

--- a/qcodes/utils/qcodes_device_annotator.py
+++ b/qcodes/utils/qcodes_device_annotator.py
@@ -10,6 +10,7 @@ import PyQt5.QtCore as core
 
 from shutil import copyfile
 import copy
+from qcodes.instrument.channel import ChannelList
 
 class MakeDeviceImage(qt.QWidget):
     """
@@ -87,6 +88,8 @@ class MakeDeviceImage(qt.QWidget):
         self.move(100, 100)
         self.setWindowTitle('Generate annotated device image')
         self.show()
+        self.raise_()
+        self.activateWindow()
 
     def select_font(self):
 
@@ -105,6 +108,27 @@ class MakeDeviceImage(qt.QWidget):
                 paramitem = gui.QStandardItem(param)
                 paramitem.setEditable(False)
                 item.appendRow(paramitem)
+
+            if station[inst].submodules:
+                for submodulename, submodule in station[inst].submodules.items():
+                    submoduleitem = gui.QStandardItem(submodulename)
+                    submoduleitem.setEditable(False)
+                    item.appendRow(submoduleitem)
+                    if isinstance(submodule, ChannelList):
+                        for channel in submodule:
+                            channelitem = gui.QStandardItem(channel.short_name)
+                            channelitem.setEditable(False)
+                            submoduleitem.appendRow(channelitem)
+                            for param in channel.parameters:
+                                paramitem = gui.QStandardItem(param)
+                                paramitem.setEditable(False)
+                                channelitem.appendRow(paramitem)
+                    else:
+                        for param in submodule.parameters:
+                            paramitem = gui.QStandardItem(param)
+                            paramitem.setEditable(False)
+                            submoduleitem.appendRow(paramitem)
+
 
     def loadimage(self):
         """
@@ -130,7 +154,7 @@ class MakeDeviceImage(qt.QWidget):
         if not self.treeView.selectedIndexes():
             return
         selected = self.treeView.selectedIndexes()[0]
-        selected_instrument = selected.parent().data()
+        selected_instrument = "_".join(self.get_full_name(selected))
         selected_parameter = selected.data()
         self.labelfield.setText("{}_{} ".format(selected_instrument, selected_parameter))
 
@@ -145,28 +169,34 @@ class MakeDeviceImage(qt.QWidget):
         if not self.treeView.selectedIndexes():
             return
         selected = self.treeView.selectedIndexes()[0]
-        selected_instrument = selected.parent().data()
+        selected_instrument = self.get_full_name(selected)
         selected_parameter = selected.data()
         self.click_x = event.pos().x()
         self.click_y = event.pos().y()
 
         # update the data
-        if selected_instrument not in self._data.keys():
-            self._data[selected_instrument] = {}
-        if selected_parameter not in self._data[selected_instrument].keys():
-            self._data[selected_instrument][selected_parameter] = {}
+        tempdict = self._data
+        for level in selected_instrument:
+            if not tempdict.get(level):
+                tempdict[level] = {}
+            tempdict = tempdict[level]
+
+        inner_data = tempdict
+
+        if selected_parameter not in inner_data.keys():
+            inner_data[selected_parameter] = {}
 
         if insertlabel:
-            self._data[selected_instrument][selected_parameter]['labelpos'] = (self.click_x, self.click_y)
-            self._data[selected_instrument][selected_parameter]['labelstring'] = self.labelfield.text()
+            inner_data[selected_parameter]['labelpos'] = (self.click_x, self.click_y)
+            inner_data[selected_parameter]['labelstring'] = self.labelfield.text()
         elif insertannotation:
-            self._data[selected_instrument][selected_parameter]['annotationpos'] = (self.click_x, self.click_y)
+            inner_data[selected_parameter]['annotationpos'] = (self.click_x, self.click_y)
             if self.formatterfield.text():
                 formatstring  = '{' + self.formatterfield.text() + "}"
-                self._data[selected_instrument][selected_parameter]['annotationformatter'] = formatstring
-                self._data[selected_instrument][selected_parameter]['value'] = formatstring
+                inner_data[selected_parameter]['annotationformatter'] = formatstring
+                inner_data[selected_parameter]['value'] = formatstring
             else:
-                self._data[selected_instrument][selected_parameter]['value'] = 'NaN'
+                inner_data[selected_parameter]['value'] = 'NaN'
 
 
         self._data['font'] = {}
@@ -179,13 +209,29 @@ class MakeDeviceImage(qt.QWidget):
         self.imageCanvas, _ = self._renderImage(self._data,
                                                 self.imageCanvas,
                                                 self.filename)
+    @staticmethod
+    def get_full_name(selected):
+        myp = selected
+        fullname = []
+        while hasattr(myp, 'parent') and not myp.parent() is None:
+            data = myp.parent().data()
+            if data is not None:
+                fullname.append(data)
+            else:
+                break
+            myp = myp.parent()
+        fullname.reverse()
+        return fullname
 
     def remove_label_and_annotation(self):
         selected = self.treeView.selectedIndexes()[0]
-        selected_instrument = selected.parent().data()
+        selected_instrument = self.get_full_name(selected)
         selected_parameter = selected.data()
-        if selected_parameter in self._data[selected_instrument].keys():
-            self._data[selected_instrument][selected_parameter] = {}
+        tempdata = self._data
+        for level in selected_instrument:
+            tempdata = tempdata[level]
+        if selected_parameter in tempdata.keys():
+            tempdata[selected_parameter] = {}
         # draw it
         self.imageCanvas, _ = self._renderImage(self._data,
                                                 self.imageCanvas,
@@ -246,9 +292,12 @@ class MakeDeviceImage(qt.QWidget):
                              core.Qt.AlignTop + core.Qt.AlignLeft,
                              title)
 
-        for instrument, parameters in data.items():
-            for parameter, paramsettings in parameters.items():
+        def recursively_paint(data):
 
+            for key, val in data.items():
+                if not hasattr(val, 'items'):
+                    continue
+                paramsettings = val
                 if 'labelpos' in paramsettings:
                     if paramsettings.get('labelstring'):
                         label_string = paramsettings.get('labelstring')
@@ -297,8 +346,12 @@ class MakeDeviceImage(qt.QWidget):
                                                  rectangle_width, rectangle_height),
                                      core.Qt.AlignCenter,
                                      annotationstring)
+                if hasattr(val, 'items'):
+                    recursively_paint(val)
 
-            canvas.setPixmap(pixmap)
+        recursively_paint(data)
+        painter.end()
+        canvas.setPixmap(pixmap)
 
         return canvas, pixmap
 
@@ -367,28 +420,35 @@ class DeviceImage:
         """
         Update the data with actual voltages from the QDac
         """
+
+        def recursiveUpdataValues(qc_inst, data, sweeptparameters):
+            for key, val in data.items():
+                try:
+                    inst_param = qc_inst.parameters[key]
+                    value = inst_param.get_latest()
+                    try:
+                        floatvalue = float(value)
+                        if val.get('annotationformatter'):
+                            valuestr = val.get('annotationformatter').format(floatvalue)
+                        elif floatvalue > 1000 or floatvalue < 0.1:
+                            valuestr = "{:.2e}".format(floatvalue)
+                        else:
+                            valuestr = "{:.2f}".format(floatvalue)
+                        if inst_param in sweeptparameters:
+                            val['update'] = True
+                    except (ValueError, TypeError):
+                        valuestr = str(value)
+                    val['value'] = valuestr
+                except KeyError:
+                    subinst = qc_inst.submodules[key]
+                    recursiveUpdataValues(subinst, val, sweeptparameters)
+
         for instrument, parameters in self._data.items():
             if instrument == 'font':
                 # skip font data
                 continue
-            for parameter in parameters.keys():
-                value = station.components[instrument][parameter].get_latest()
-                try:
-                    floatvalue = float(station.components[instrument][parameter].get_latest())
-                    if self._data[instrument][parameter].get('annotationformatter'):
-                        valuestr = self._data[instrument][parameter].get('annotationformatter').format(floatvalue)
-                    elif floatvalue > 1000 or floatvalue < 0.1:
-                        valuestr = "{:.2e}".format(floatvalue)
-                    else:
-                        valuestr = "{:.2f}".format(floatvalue)
-                except (ValueError, TypeError):
-                    valuestr = str(value)
-                self._data[instrument][parameter]['value'] = valuestr
-                if sweeptparameters:
-                    for sweeptparameter in sweeptparameters:
-                        if sweeptparameter._instrument.name == instrument and sweeptparameter.name == parameter:
-                            self._data[instrument][parameter]['update'] = True
-
+            qc_inst = station.components[instrument]
+            recursiveUpdataValues(qc_inst, parameters, sweeptparameters)
 
     def makePNG(self, counter, path=None, title=None):
         """

--- a/qcodes/utils/qcodes_device_annotator.py
+++ b/qcodes/utils/qcodes_device_annotator.py
@@ -324,7 +324,7 @@ class DeviceImage:
             app = qt.QApplication(sys.argv)
         else:
             app = qt.QApplication.instance()
-        imagedrawer = MakeDeviceImage(self.folder, self.station)
+        self.imagedrawer = MakeDeviceImage(self.folder, self.station)
         print("Please annotate device image")
         app.exec_()
 

--- a/qcodes/utils/qcodes_device_annotator.py
+++ b/qcodes/utils/qcodes_device_annotator.py
@@ -11,6 +11,7 @@ import PyQt5.QtCore as core
 from shutil import copyfile
 import copy
 from qcodes.instrument.channel import ChannelList
+from qcodes.utils.helpers import forground_qt_window
 
 class MakeDeviceImage(qt.QWidget):
     """
@@ -89,7 +90,7 @@ class MakeDeviceImage(qt.QWidget):
         self.setWindowTitle('Generate annotated device image')
         self.show()
         self.raise_()
-        self.activateWindow()
+        forground_qt_window(self)
 
     def select_font(self):
 

--- a/qcodes/utils/wrappers.py
+++ b/qcodes/utils/wrappers.py
@@ -350,6 +350,7 @@ def save_device_image(sweeptparameters):
     counter = CURRENT_EXPERIMENT['provider'].counter
     title = "{} #{:03d}".format(CURRENT_EXPERIMENT["sample_name"], counter)
     di = CURRENT_EXPERIMENT['device_image']
+    status = True
     if di.filename == None:
         status = di.loadAnnotations()
 

--- a/qcodes/utils/wrappers.py
+++ b/qcodes/utils/wrappers.py
@@ -15,6 +15,7 @@ from qcodes.plots.pyqtgraph import QtPlot
 from qcodes.plots.qcmatplotlib import MatPlot
 from qcodes.instrument.visa import VisaInstrument
 from qcodes.utils.qcodes_device_annotator import DeviceImage
+from qcodes.utils.helpers import forground_qt_window
 
 from matplotlib import ticker
 from IPython import get_ipython
@@ -220,6 +221,7 @@ def _plot_setup(data, inst_meas, useQT=True, startranges=None):
                                           tdict[whatwhere[setarr.label]])
                     (rmin, rmax) = startranges[setarr.label]
                     rangesetter(rmin, rmax)
+            QtPlot.qc_helpers.forground_qt_window(plot.win)
 
         else:
             if 'z' in inst_meta_data:

--- a/qcodes/utils/wrappers.py
+++ b/qcodes/utils/wrappers.py
@@ -350,6 +350,14 @@ def save_device_image(sweeptparameters):
     counter = CURRENT_EXPERIMENT['provider'].counter
     title = "{} #{:03d}".format(CURRENT_EXPERIMENT["sample_name"], counter)
     di = CURRENT_EXPERIMENT['device_image']
+    if di.filename == None:
+        status = di.loadAnnotations()
+
+    if not status:
+        log.warning("Could not load deviceannotation from disk. "
+                    "No device image with be genereted for this "
+                    "run")
+        return
     di.updateValues(CURRENT_EXPERIMENT['station'], sweeptparameters)
 
     log.debug(os.path.join(CURRENT_EXPERIMENT["exp_folder"],

--- a/qcodes/utils/wrappers.py
+++ b/qcodes/utils/wrappers.py
@@ -15,7 +15,6 @@ from qcodes.plots.pyqtgraph import QtPlot
 from qcodes.plots.qcmatplotlib import MatPlot
 from qcodes.instrument.visa import VisaInstrument
 from qcodes.utils.qcodes_device_annotator import DeviceImage
-from qcodes.utils.helpers import forground_qt_window
 
 from matplotlib import ticker
 from IPython import get_ipython
@@ -221,7 +220,7 @@ def _plot_setup(data, inst_meas, useQT=True, startranges=None):
                                           tdict[whatwhere[setarr.label]])
                     (rmin, rmax) = startranges[setarr.label]
                     rangesetter(rmin, rmax)
-            QtPlot.qc_helpers.forground_qt_window(plot.win)
+            QtPlot.qc_helpers.foreground_qt_window(plot.win)
 
         else:
             if 'z' in inst_meta_data:


### PR DESCRIPTION
app.exec_ is not blocking with IPython event loop integration so the app would close instantly. Rather than closing in the same function rely on users closing and store the datafile within the annotator. This may require loading from desk when generating the image
